### PR TITLE
Add sample BOINC training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # AGI
+
+This repository demonstrates a minimal pipeline for decentralized model training using the [BOINC](https://boinc.berkeley.edu/) server tools. Volunteers download tasks, perform local fine‑tuning on small quantized models and send weight updates back to the server.
+
+## Steps in brief
+
+1. **Install the BOINC server tools**
+   ```bash
+   sudo apt-get install boinc-server-maker boinc-server-binaries boinc-server-tools
+   ```
+   See the BOINC wiki for complete instructions.
+2. **Create a project directory**
+   ```bash
+   make_project agiNet
+   cd agiNet
+   ```
+3. **Add the skill apps** under `apps/`.
+   Example subfolders:
+   - `apps/vision`
+   - `apps/language`
+   - `apps/memory`
+   - `apps/planner`
+   Each folder should contain a small quantized model file and a `train_local.py` runner.
+4. **Prepare the training script**.
+   `train_local.py` loads the weights, fine‑tunes on the provided dataset and writes weight deltas and a reward score.
+5. **Create work-unit templates** using `wu_template.xml` and `result_template.xml`. Each work unit contains the skill name, current weights, a mini dataset or prompts and the training script.
+6. **Generate work units** with `sched_create_work` so volunteers can download tasks.
+7. **Validate returned work** using `validator.py`. Check hashes, run a quick evaluation and reject results that score below a threshold.
+8. **Aggregate accepted updates** nightly with `fed_avg.py` which performs federated averaging and writes updated global weights. Bump `version_num` in `app_version.xml` so future tasks fetch the new weights.
+9. **Grant BOINC credit** only when a node’s update passed validation to keep volunteers honest.
+10. **Publish snapshots and metrics** so others can track progress.
+
+The `server/` directory of this repository provides example scripts and templates to get started.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,12 @@
+# Server scripts
+
+This folder contains example files for running a BOINC-based training project.
+Copy its contents into the project directory created by `make_project`.
+
+- `apps/` contains subdirectories for each skill. Put the quantized model file
+  and `train_local.py` runner in each.
+- `wu_template.xml` and `result_template.xml` describe the input and output
+  files for a work unit.
+- `validator.py` checks returned results.
+- `fed_avg.py` aggregates accepted weight deltas.
+- `setup_project.sh` demonstrates how to generate work units.

--- a/server/apps/language/README.md
+++ b/server/apps/language/README.md
@@ -1,0 +1,1 @@
+Placeholder for language model and runner

--- a/server/apps/language/train_local.py
+++ b/server/apps/language/train_local.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple local fine-tuning script")
+    parser.add_argument("--weights", required=True, help="Initial model weights")
+    parser.add_argument("--data", required=True, help="Training data chunk")
+    parser.add_argument("--output", required=True, help="Output file for weight deltas")
+    args = parser.parse_args()
+
+    # In a real setup you would load the model and perform fine-tuning here.
+    # This example only writes a placeholder delta and reward.
+    output = Path(args.output)
+    output.write_text("delta: 0\nreward: 0.0\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/apps/memory/README.md
+++ b/server/apps/memory/README.md
@@ -1,0 +1,1 @@
+Placeholder for memory model and runner

--- a/server/apps/memory/train_local.py
+++ b/server/apps/memory/train_local.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple local fine-tuning script")
+    parser.add_argument("--weights", required=True, help="Initial model weights")
+    parser.add_argument("--data", required=True, help="Training data chunk")
+    parser.add_argument("--output", required=True, help="Output file for weight deltas")
+    args = parser.parse_args()
+
+    # In a real setup you would load the model and perform fine-tuning here.
+    # This example only writes a placeholder delta and reward.
+    output = Path(args.output)
+    output.write_text("delta: 0\nreward: 0.0\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/apps/planner/README.md
+++ b/server/apps/planner/README.md
@@ -1,0 +1,1 @@
+Placeholder for planner model and runner

--- a/server/apps/planner/train_local.py
+++ b/server/apps/planner/train_local.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple local fine-tuning script")
+    parser.add_argument("--weights", required=True, help="Initial model weights")
+    parser.add_argument("--data", required=True, help="Training data chunk")
+    parser.add_argument("--output", required=True, help="Output file for weight deltas")
+    args = parser.parse_args()
+
+    # In a real setup you would load the model and perform fine-tuning here.
+    # This example only writes a placeholder delta and reward.
+    output = Path(args.output)
+    output.write_text("delta: 0\nreward: 0.0\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/apps/train_local.py
+++ b/server/apps/train_local.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple local fine-tuning script")
+    parser.add_argument("--weights", required=True, help="Initial model weights")
+    parser.add_argument("--data", required=True, help="Training data chunk")
+    parser.add_argument("--output", required=True, help="Output file for weight deltas")
+    args = parser.parse_args()
+
+    # In a real setup you would load the model and perform fine-tuning here.
+    # This example only writes a placeholder delta and reward.
+    output = Path(args.output)
+    output.write_text("delta: 0\nreward: 0.0\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/apps/vision/README.md
+++ b/server/apps/vision/README.md
@@ -1,0 +1,1 @@
+Placeholder for vision model and runner

--- a/server/apps/vision/train_local.py
+++ b/server/apps/vision/train_local.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple local fine-tuning script")
+    parser.add_argument("--weights", required=True, help="Initial model weights")
+    parser.add_argument("--data", required=True, help="Training data chunk")
+    parser.add_argument("--output", required=True, help="Output file for weight deltas")
+    args = parser.parse_args()
+
+    # In a real setup you would load the model and perform fine-tuning here.
+    # This example only writes a placeholder delta and reward.
+    output = Path(args.output)
+    output.write_text("delta: 0\nreward: 0.0\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/fed_avg.py
+++ b/server/fed_avg.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+
+def aggregate(delta_paths):
+    # Placeholder aggregator: just average numbers from delta files
+    totals = []
+    for p in delta_paths:
+        with open(p) as f:
+            for line in f:
+                if line.startswith("delta:"):
+                    val = float(line.split(":",1)[1].strip())
+                    totals.append(val)
+    if not totals:
+        return 0.0
+    return sum(totals) / len(totals)
+
+
+def main():
+    deltas = [Path(p) for p in sys.argv[1:]]
+    new_weight = aggregate(deltas)
+    print(f"new_weight={new_weight}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/result_template.xml
+++ b/server/result_template.xml
@@ -1,0 +1,6 @@
+<result>
+    <file_info>
+        <name>output.txt</name>
+        <generated_locally/>
+    </file_info>
+</result>

--- a/server/setup_project.sh
+++ b/server/setup_project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Example script for creating work units inside a BOINC project directory.
+# Run this after `make_project agiNet` and copy the contents of `server/` there.
+
+set -e
+
+for skill in vision language memory planner; do
+    ./bin/sched_create_work \
+        --appname "$skill" \
+        --wu_name "${skill}_wu" \
+        --wu_template ./wu_template.xml \
+        --result_template ./result_template.xml
+done

--- a/server/validator.py
+++ b/server/validator.py
@@ -1,0 +1,25 @@
+import hashlib
+import sys
+from pathlib import Path
+
+
+def validate(delta_path: Path) -> float:
+    # TODO: add real evaluation. For now accept everything with reward 1.0
+    if not delta_path.exists():
+        return 0.0
+    return 1.0
+
+
+def main():
+    delta_file = Path(sys.argv[1])
+    score = validate(delta_file)
+    if score > 0:
+        print(f"ACCEPT {score}")
+        sys.exit(0)
+    else:
+        print("REJECT")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/wu_template.xml
+++ b/server/wu_template.xml
@@ -1,0 +1,9 @@
+<workunit>
+    <file_info>
+        <name><input_filename/></name>
+        <nbytes><input_filesize/></nbytes>
+    </file_info>
+    <command>
+        python apps/<skill>/train_local.py --weights <input_weights> --data <input_data> --output output.txt
+    </command>
+</workunit>


### PR DESCRIPTION
## Summary
- expand README with instructions for running BOINC-based decentralized training
- add `server/` folder containing example scripts and templates

## Testing
- `python3 -m py_compile server/apps/train_local.py server/validator.py server/fed_avg.py`
