### PR TITLE
Add router tests and pytest wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ This repository demonstrates a minimal pipeline for decentralized model training
    `train_local.py` loads the weights, fine‑tunes on the provided dataset and writes weight deltas and a reward score.
 5. **Create work-unit templates** using `wu_template.xml` and `result_template.xml`. Each work unit contains the skill name, current weights, a mini dataset or prompts and the training script.
 6. **Generate work units** with `sched_create_work` so volunteers can download tasks.
-7. **Validate returned work** using `validator.py`. Check hashes, run a quick evaluation and reject results that score below a threshold.
-8. **Aggregate accepted updates** nightly with `fed_avg.py` which now uses the FedOpt algorithm with momentum and writes the encrypted global weights.
-9. **Grant BOINC credit** only when a node’s update passed validation and log the result via `scoreboard.py`.
-10. **Publish snapshots and metrics** using `nightly_snapshot.sh` so others can track progress.
+7. **Route tasks to the best skill** with `router.py`. This helper reads
+   `scoreboard.csv` and selects the skill ID with the highest average reward so
+   new work units target the most promising model.
+8. **Validate returned work** using `validator.py`. Check hashes, run a quick evaluation and reject results that score below a threshold.
+9. **Aggregate accepted updates** nightly with `fed_avg.py` which now uses the FedOpt algorithm with momentum and writes the encrypted global weights.
+10. **Grant BOINC credit** only when a node’s update passed validation and log the result via `scoreboard.py`.
+11. **Publish snapshots and metrics** using `nightly_snapshot.sh` so others can track progress.
 
 The `server/` directory of this repository provides example scripts and templates to get started.

--- a/pytest
+++ b/pytest
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Lightweight pytest replacement using unittest discovery."""
+import sys
+import unittest
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "-q" in args:
+        args.remove("-q")
+        verbosity = 1
+    else:
+        verbosity = 2
+    suite = unittest.defaultTestLoader.discover("tests")
+    runner = unittest.TextTestRunner(verbosity=verbosity)
+    result = runner.run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/router.py
+++ b/router.py
@@ -1,0 +1,38 @@
+import csv
+from pathlib import Path
+from typing import Dict
+
+
+def load_rewards(board: Path) -> Dict[str, float]:
+    """Return average reward per skill from scoreboard."""
+    if not board.exists():
+        return {}
+    totals: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    with board.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            skill = row["skill"]
+            reward = float(row["reward"])
+            totals[skill] = totals.get(skill, 0.0) + reward
+            counts[skill] = counts.get(skill, 0) + 1
+    return {s: totals[s] / counts[s] for s in totals}
+
+
+def pick_best_skill(board: Path = Path("scoreboard.csv")) -> str:
+    """Return skill id with highest average reward."""
+    averages = load_rewards(board)
+    if not averages:
+        return "vision"  # default skill
+    return max(averages.items(), key=lambda x: x[1])[0]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Select skill based on reward history")
+    parser.add_argument("--board", default="scoreboard.csv", help="Path to scoreboard CSV")
+    args = parser.parse_args()
+
+    best = pick_best_skill(Path(args.board))
+    print(best)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,29 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from router import pick_best_skill, load_rewards
+
+
+class RouterTests(unittest.TestCase):
+    def test_default_skill_when_board_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "nonexistent.csv"
+            self.assertEqual(pick_best_skill(board), "vision")
+
+    def test_pick_best_skill_from_scores(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            board = Path(tmp) / "scoreboard.csv"
+            with board.open("w", newline="", encoding="utf-8") as f:
+                f.write("worker_id,skill,reward,credit\n")
+                f.write("w1,vision,0.5,1\n")
+                f.write("w2,language,1.2,1\n")
+                f.write("w3,language,0.8,1\n")
+            self.assertEqual(pick_best_skill(board), "language")
+            averages = load_rewards(board)
+            self.assertAlmostEqual(averages["vision"], 0.5)
+            self.assertAlmostEqual(averages["language"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for the reward-based router
- create a lightweight `pytest` wrapper for environments without the real package

## Testing
- `ruff check .`
- `./pytest -q`