### PR TITLE
Remove offline wheelhouse

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-wheelhouse/*.whl filter=lfs diff=lfs merge=lfs -text
-wheelhouse/ruff-*.whl filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,6 @@ fedopt_state.json
 global_weights.enc
 next_wu_id.txt
 
-# Offline wheels
-wheelhouse/
 
 # Backup files
 *.repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
     rm -rf /var/lib/apt/lists/*
 
-# offline wheel cache
-COPY wheelhouse /app/wheelhouse
-ENV PIP_FIND_LINKS=/app/wheelhouse \
-    PIP_NO_INDEX=1
-
-# install all Python deps from wheels
-RUN pip install torch torchvision torchaudio \
-    requests cryptography rich ruff pytest
+# install Python dependencies
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
 
 # copy project & set entrypoint
 WORKDIR /app

--- a/wheelhouse/filelock-3.18.0-py3-none-any.whl
+++ b/wheelhouse/filelock-3.18.0-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de
-size 16215

--- a/wheelhouse/fsspec-2025.3.2-py3-none-any.whl
+++ b/wheelhouse/fsspec-2025.3.2-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711
-size 194435

--- a/wheelhouse/jinja2-3.1.6-py3-none-any.whl
+++ b/wheelhouse/jinja2-3.1.6-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-size 134899

--- a/wheelhouse/mpmath-1.3.0-py3-none-any.whl
+++ b/wheelhouse/mpmath-1.3.0-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
-size 536198

--- a/wheelhouse/networkx-3.4.2-py3-none-any.whl
+++ b/wheelhouse/networkx-3.4.2-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f
-size 1723263

--- a/wheelhouse/setuptools-80.7.1-py3-none-any.whl
+++ b/wheelhouse/setuptools-80.7.1-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca5cc1069b85dc23070a6628e6bcecb3292acac802399c7f8edc0100619f9009
-size 1200776

--- a/wheelhouse/typing_extensions-4.13.2-py3-none-any.whl
+++ b/wheelhouse/typing_extensions-4.13.2-py3-none-any.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c
-size 45806


### PR DESCRIPTION
## Summary
- drop lfs attributes for wheels
- install dependencies directly in Dockerfile
- stop ignoring local wheel cache

## Testing
- `pytest -q`
