### PR TITLE
Handle metrics-formatted delta files

### DIFF
--- a/client/apply_delta.py
+++ b/client/apply_delta.py
@@ -2,9 +2,41 @@ import argparse
 from pathlib import Path
 
 
+def _read_float(path: Path) -> float:
+    """Return the first float value stored in ``path``.
+
+    Training scripts emit metric files containing multiple ``key: value``
+    pairs (see ``server/apps/*/train_local.py``).  The previous
+    implementation assumed the file only contained a raw floating point
+    number, which meant the simulated volunteer could not apply the
+    aggregated update it just produced.  To make the pipeline compatible
+    with the generated files we look for a ``delta`` key while still
+    supporting legacy files that only contain the numeric value.
+    """
+
+    text = path.read_text().strip()
+    if not text:
+        raise ValueError(f"{path} is empty")
+
+    # Fast path for legacy files that only contain a float.
+    try:
+        return float(text)
+    except ValueError:
+        pass
+
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        if key.strip().lower() == "delta":
+            return float(value.strip())
+
+    raise ValueError(f"delta value not found in {path}")
+
+
 def apply_delta(weight_file: Path, delta_file: Path, out_file: Path) -> None:
-    weight = float(weight_file.read_text().strip())
-    delta = float(delta_file.read_text().strip())
+    weight = _read_float(weight_file)
+    delta = _read_float(delta_file)
     out_file.write_text(str(weight + delta))
 
 

--- a/tests/test_apply_delta.py
+++ b/tests/test_apply_delta.py
@@ -1,0 +1,34 @@
+import tempfile
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from client.apply_delta import apply_delta, _read_float
+
+
+def test_read_float_accepts_plain_number() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "value.txt"
+        p.write_text("1.23")
+        assert _read_float(p) == 1.23
+
+
+def test_read_float_parses_metric_file() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "metrics.txt"
+        p.write_text("reward:1.0\ndelta: 0.5\n")
+        assert _read_float(p) == 0.5
+
+
+def test_apply_delta_writes_sum(tmp_path: Path) -> None:
+    weight = tmp_path / "weight.txt"
+    delta = tmp_path / "delta.txt"
+    out = tmp_path / "out.txt"
+    weight.write_text("1.0")
+    delta.write_text("delta: 0.25\nreward: 0.8\n")
+
+    apply_delta(weight, delta, out)
+
+    assert out.read_text() == "1.25"


### PR DESCRIPTION
## Summary
- update the volunteer delta application helper to read metric files that contain key/value pairs
- add regression tests covering both legacy single-value files and the new metric format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c886dcc2b0832986c8014e8d29c694