### PR TITLE
Add jinja2 dependency to runtime manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.10"
 requests = "^2.31"
 cryptography = "^42.0"
 rich = "^13.7"
+jinja2 = "^3.1"
 
 # Optional heavyweight deps for worker images
 torch = {version = "^2.2", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 requests
 cryptography
 rich
+jinja2
 pytest
 ruff
 torch


### PR DESCRIPTION
## Summary
- add jinja2 to runtime `requirements.txt`
- mirror the dependency under `[tool.poetry.dependencies]`

## Testing
- ⚠️ `poetry lock` *(fails: pypi.org unreachable from sandbox)*
- ✅ `PYTHONPATH=. python server/resource_sharder.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c9b7927f6483299d7f7ca27c36ea45