### PR TITLE
Support bundled weights fallback when generating WUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ router.py -> scheduler.py -> generate_wu.py -> BOINC -> volunteer.py -> validato
 
 The `server/` directory of this repository provides example scripts and templates to get started.
 
+### Generating a work unit with the bundled weights
+
+`server/generate_wu.py` first looks for `apps/<skill>/init_weights.txt` in the current
+project directory. When you run the script directly from this repository, it will
+automatically fall back to the reference weights stored under `server/apps/`.
+You can verify the setup with a tiny sample file:
+
+```bash
+echo "dummy prompt" > sample.dat
+python server/generate_wu.py --skill vision --data sample.dat --out wu_dir
+```
+
+The command copies the input data and bundled weights into `wu_dir/` and emits a
+`wu_*.xml` description that can be uploaded with the BOINC server tools.
+
 ## Resource-aware sharding
 
 Large community grids often have a mix of resource tiers.  Use `server/resource_sharder.py`

--- a/server/generate_wu.py
+++ b/server/generate_wu.py
@@ -67,7 +67,17 @@ def create_wu(
     data_dst = out_dir / f"{wid}_{data_src.name}"
     shutil.copy2(data_src, data_dst)
 
-    weights_src = Path(f"apps/{skill}/init_weights.txt")
+    project_weights = Path("apps") / skill / "init_weights.txt"
+    bundled_weights = Path(__file__).resolve().parent / "apps" / skill / "init_weights.txt"
+
+    if project_weights.exists():
+        weights_src = project_weights
+    elif bundled_weights.exists():
+        weights_src = bundled_weights
+    else:
+        raise FileNotFoundError(
+            "init_weights.txt not found in project apps/ or bundled server/apps directories"
+        )
     weights_dst = out_dir / f"{wid}_{weights_src.name}"
     shutil.copy2(weights_src, weights_dst)
 


### PR DESCRIPTION
## Summary
- make generate_wu.py fall back to the bundled server/apps weights when project apps/ files are missing
- document how to invoke generate_wu.py directly from the repository using the bundled weights

## Testing
- python server/generate_wu.py --skill vision --data sample.dat --out wu_dir

------
https://chatgpt.com/codex/tasks/task_e_68c9b7709a408329920b087a82457314