### PR TITLE
Update generate_wu weight lookup order

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -7,3 +7,16 @@ This folder contains example files for running a BOINC-based training project. C
 - `validator.py` checks returned results.
 - `fed_avg.py` aggregates accepted weight deltas.
 - `setup_project.sh` demonstrates how to generate work units.
+
+## Generating work units from the repository root
+
+The helper script can be called directly from the repository root. It first looks for
+bundled weight files under `server/apps/` and falls back to a legacy `apps/` directory if
+you have already copied the project assets elsewhere.
+
+```bash
+python server/generate_wu.py \
+  --skill language \
+  --data /path/to/chunk.jsonl \
+  --out work_units/language
+```

--- a/server/generate_wu.py
+++ b/server/generate_wu.py
@@ -67,16 +67,16 @@ def create_wu(
     data_dst = out_dir / f"{wid}_{data_src.name}"
     shutil.copy2(data_src, data_dst)
 
-    project_weights = Path("apps") / skill / "init_weights.txt"
     bundled_weights = Path(__file__).resolve().parent / "apps" / skill / "init_weights.txt"
+    legacy_weights = Path("apps") / skill / "init_weights.txt"
 
-    if project_weights.exists():
-        weights_src = project_weights
-    elif bundled_weights.exists():
+    if bundled_weights.exists():
         weights_src = bundled_weights
+    elif legacy_weights.exists():
+        weights_src = legacy_weights
     else:
         raise FileNotFoundError(
-            "init_weights.txt not found in project apps/ or bundled server/apps directories"
+            "init_weights.txt not found in bundled server/apps or legacy project apps/ directories"
         )
     weights_dst = out_dir / f"{wid}_{weights_src.name}"
     shutil.copy2(weights_src, weights_dst)


### PR DESCRIPTION
## Summary
- prefer the bundled server/apps weights when generating work units and retain the legacy apps/ fallback
- document how to invoke the work unit generator from the repository root and explain the fallback behaviour

## Testing
- python server/generate_wu.py   --skill language   --data /tmp/agi_wu/chunk.jsonl   --out tmp/wu_language
- python server/generate_wu.py   --skill language   --data /tmp/agi_wu/chunk.jsonl   --out tmp/wu_language_legacy


------
https://chatgpt.com/codex/tasks/task_e_68c9b93545a08329894d4d800647bf38