### PR TITLE
Add Jinja2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.10"
 requests = "^2.31"
 cryptography = "^42.0"
 rich = "^13.7"
-jinja2 = "^3.1"
+jinja2 = "^3.1.4"
 
 # Optional heavyweight deps for worker images
 torch = {version = "^2.2", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 requests
 cryptography
 rich
-jinja2
+jinja2>=3.1.4,<4.0.0
 pytest
 ruff
 torch


### PR DESCRIPTION
## Summary
- add an explicit Jinja2 runtime dependency to Poetry with the latest 3.1 patch bound
- align the requirements.txt entry with an equivalent version range

## Testing
- pip install -r requirements.txt *(fails: outbound PyPI access is blocked in the execution environment)*
- python server/resource_sharder.py --help *(fails without Jinja2 because dependencies cannot be installed offline)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b933b0488329959bcfa36f4b4340