### PR TITLE
Bump Jinja2 dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.10"
 requests = "^2.31"
 cryptography = "^42.0"
 rich = "^13.7"
-jinja2 = "^3.1.4"
+jinja2 = "^3.1.6"
 
 # Optional heavyweight deps for worker images
 torch = {version = "^2.2", optional = true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 requests
 cryptography
 rich
-jinja2>=3.1.4,<4.0.0
+jinja2>=3.1.6,<4.0.0
 pytest
 ruff
 torch


### PR DESCRIPTION
## Summary
- require Jinja2 3.1.6 in requirements.txt and pyproject metadata

## Testing
- `PYTHONPATH=. python server/resource_sharder.py --help`
- `poetry lock` *(fails: offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e1f92be08329a0aa038519b1b528