### PR TITLE
Fix server weight discovery from repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ The `server/` directory of this repository provides example scripts and template
 
 ### Generating a work unit with the bundled weights
 
-`server/generate_wu.py` first looks for `apps/<skill>/init_weights.txt` in the current
-project directory. When you run the script directly from this repository, it will
-automatically fall back to the reference weights stored under `server/apps/`.
+`server/generate_wu.py` first looks for `init_weights.txt` bundled alongside the script in
+`server/apps/<skill>/`. Legacy projects that keep weights in a top-level
+`apps/<skill>/` directory are still supported as a fallback. This means you can run the
+helper from the repository root without `cd`-ing into `server/`.
 You can verify the setup with a tiny sample file:
 
 ```bash

--- a/server/resource_sharder.py
+++ b/server/resource_sharder.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import sys
 from dataclasses import dataclass
 from itertools import cycle
 from pathlib import Path
 from typing import Iterable, List, Sequence
 
-from server.generate_wu import create_wu
+try:
+    from server.generate_wu import create_wu
+except ModuleNotFoundError:  # pragma: no cover - allows running as a script from repo root
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from generate_wu import create_wu
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- resolve bundled work-unit templates and weight files relative to the server scripts with a legacy fallback
- document the search order in the README so the helper scripts can be run from the repository root
- allow `resource_sharder.py` to import `generate_wu` when invoked directly, matching the README usage

## Testing
- python server/resource_sharder.py --skill vision --data server/apps/vision/README.md --resources /tmp/resources.json --out /tmp/wu_test --base-steps 10 --base-lr 0.001

------
https://chatgpt.com/codex/tasks/task_e_68c9e1fc679883299601e30a2bcfdfb6